### PR TITLE
feat(storage): tombstone dismissed items (T1-A, closes #1)

### DIFF
--- a/news_agent/config.py
+++ b/news_agent/config.py
@@ -148,6 +148,14 @@ class Settings(BaseSettings):
     batch_size: int = 15
     max_items_per_source: int = 50
 
+    # ── Personalization ───────────────────────────────────────────────────────
+    # When True, a user downvote inserts a row in DismissedItemORM and the item
+    # is hidden from get_recent() / search() across sessions and re-fetches.
+    # Upvoting (or explicitly un-downvoting) a dismissed item clears its tombstone.
+    # Set False to preserve legacy behaviour where downvotes only influenced
+    # future ranking scores without hiding the downvoted item itself.
+    dismiss_on_downvote: bool = True
+
     # ── Storage ───────────────────────────────────────────────────────────────
     database_url: str = "sqlite+aiosqlite:///data/news.db"
     retention_days: int = 30

--- a/news_agent/models.py
+++ b/news_agent/models.py
@@ -154,3 +154,18 @@ class CollectorStateORM(Base):
     is_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     youtube_quota_used: Mapped[int] = mapped_column(default=0)
     youtube_quota_reset_date: Mapped[str | None] = mapped_column(String(10), nullable=True)
+
+
+class DismissedItemORM(Base):
+    """Tombstone for items the user has explicitly dismissed (e.g. via downvote).
+
+    Keyed by item_id so a re-fetch of the same (source, url) pair — which
+    re-upserts the same sha256(source:url)[:16] id — stays hidden. This closes
+    the loop on downvotes that otherwise only reshape future ranking but
+    never suppress the dismissed item itself.
+    """
+    __tablename__ = "dismissed_items"
+
+    item_id: Mapped[str] = mapped_column(String(16), primary_key=True)
+    dismissed_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, index=True)
+    reason: Mapped[str | None] = mapped_column(String(32), nullable=True)  # "downvote" | "manual" | ...

--- a/news_agent/storage/repository.py
+++ b/news_agent/storage/repository.py
@@ -9,7 +9,15 @@ from sqlalchemy import delete, select, text, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from news_agent.models import CollectorStateORM, DigestORM, NewsItem, NewsItemORM, UserSettingORM
+from news_agent.config import settings
+from news_agent.models import (
+    CollectorStateORM,
+    DigestORM,
+    DismissedItemORM,
+    NewsItem,
+    NewsItemORM,
+    UserSettingORM,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +109,37 @@ class NewsRepository:
         result = await self.session.get(NewsItemORM, item_id)
         return result is not None
 
+    # ── Dismissal / tombstones ────────────────────────────────────────────────
+
+    async def dismiss(self, item_id: str, reason: str | None = "downvote") -> None:
+        """Insert a tombstone so the item is hidden from get_recent/search.
+        Idempotent — dismissing an already-dismissed item is a no-op."""
+        stmt = sqlite_insert(DismissedItemORM).values(
+            item_id=item_id,
+            dismissed_at=datetime.utcnow(),
+            reason=reason,
+        )
+        stmt = stmt.on_conflict_do_nothing(index_elements=["item_id"])
+        await self.session.execute(stmt)
+
+    async def undismiss(self, item_id: str) -> None:
+        """Remove the tombstone so the item is visible again.
+        Idempotent — no-op if not dismissed."""
+        await self.session.execute(
+            delete(DismissedItemORM).where(DismissedItemORM.item_id == item_id)
+        )
+
+    async def is_dismissed(self, item_id: str) -> bool:
+        result = await self.session.get(DismissedItemORM, item_id)
+        return result is not None
+
+    def _dismissed_subquery(self):
+        """Scalar subquery of tombstoned item_ids, for NOT IN filters.
+        Returns None when the feature is flagged off so the filter is skipped."""
+        if not settings.dismiss_on_downvote:
+            return None
+        return select(DismissedItemORM.item_id).scalar_subquery()
+
     async def get_recent(
         self,
         hours: float = 24,
@@ -124,6 +163,9 @@ class NewsRepository:
             q = q.where(NewsItemORM.is_duplicate == False)  # noqa: E712
         if languages:
             q = q.where(NewsItemORM.language.in_(languages))
+        dismissed = self._dismissed_subquery()
+        if dismissed is not None:
+            q = q.where(NewsItemORM.id.notin_(dismissed))
         q = q.order_by(
             # Most recently fetched batch first — newly retrieved items appear at top
             # before analysis fills in their relevance scores.
@@ -185,6 +227,9 @@ class NewsRepository:
         ]
         if languages:
             base_where.append(NewsItemORM.language.in_(languages))
+        dismissed = self._dismissed_subquery()
+        if dismissed is not None:
+            base_where.append(NewsItemORM.id.notin_(dismissed))
 
         # Hybrid BM25 + semantic with RRF merge. BM25 catches exact keyword/ticker
         # matches; semantic catches paraphrases and related concepts.

--- a/news_agent/web/app.py
+++ b/news_agent/web/app.py
@@ -424,6 +424,15 @@ async def log_interaction(payload: InteractionPayload):
     async with get_session() as session:
         await _cancel_opposite_vote(session, payload.item_id, payload.action)
         await record_interaction(session, payload.item_id, payload.action, payload.read_seconds)
+        # Tombstone lifecycle: downvote hides the item across re-fetches;
+        # upvote / undownvote clears the tombstone. Respects the feature flag.
+        if _settings.dismiss_on_downvote:
+            from news_agent.storage.repository import NewsRepository as _Repo
+            repo = _Repo(session)
+            if payload.action == "downvote":
+                await repo.dismiss(payload.item_id, reason="downvote")
+            elif payload.action in ("upvote", "undownvote"):
+                await repo.undismiss(payload.item_id)
         await recompute_preferences(session)
     return {"ok": True}
 

--- a/tests/storage/test_repository_extended.py
+++ b/tests/storage/test_repository_extended.py
@@ -284,3 +284,108 @@ async def test_get_all_collector_states_returns_all():
         states = await repo.get_all_collector_states()
     sources = {s.source for s in states}
     assert {"src_a", "src_b", "src_c"}.issubset(sources)
+
+
+# ── dismissed_items tombstones (T1-A / issue #1) ──────────────────────────────
+
+@pytest.mark.asyncio
+async def test_dismiss_inserts_tombstone_row():
+    from news_agent.models import DismissedItemORM
+    from sqlalchemy import select
+
+    item = make_item(url="https://example.com/dismiss-row", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+        await repo.dismiss(item.id, reason="downvote")
+        result = await session.execute(
+            select(DismissedItemORM).where(DismissedItemORM.item_id == item.id)
+        )
+        row = result.scalar_one_or_none()
+    assert row is not None
+    assert row.item_id == item.id
+    assert row.reason == "downvote"
+    assert row.dismissed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_dismiss_is_idempotent():
+    """Dismissing an already-dismissed item must not raise or create duplicates."""
+    from news_agent.models import DismissedItemORM
+    from sqlalchemy import func, select
+
+    item = make_item(url="https://example.com/dismiss-idempotent", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+        await repo.dismiss(item.id)
+        await repo.dismiss(item.id)
+        await repo.dismiss(item.id)
+        count = await session.execute(
+            select(func.count()).select_from(DismissedItemORM).where(DismissedItemORM.item_id == item.id)
+        )
+    assert count.scalar() == 1
+
+
+@pytest.mark.asyncio
+async def test_get_recent_excludes_dismissed_items():
+    a = make_item(url="https://example.com/recent-a", published_at=hours_ago(1))
+    b = make_item(url="https://example.com/recent-b", published_at=hours_ago(1))
+    c = make_item(url="https://example.com/recent-c", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        for it in (a, b, c):
+            await repo.upsert(it)
+        await repo.dismiss(b.id)
+        items = await repo.get_recent(hours=24)
+    ids = {i.id for i in items}
+    assert a.id in ids
+    assert c.id in ids
+    assert b.id not in ids
+
+
+@pytest.mark.asyncio
+async def test_dismissed_item_stays_hidden_after_reupsert():
+    """Core regression: re-fetching a dismissed item (same id via same
+    source+url) must NOT make it reappear in get_recent."""
+    item = make_item(url="https://example.com/sticky-dismiss", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+        await repo.dismiss(item.id)
+        # Simulate the scheduler re-fetching the same article from the feed:
+        # same source+url → same sha256(source:url)[:16] id → same upsert target.
+        await repo.upsert(item)
+        assert await repo.is_dismissed(item.id) is True
+        items = await repo.get_recent(hours=24)
+    assert item.id not in {i.id for i in items}
+
+
+@pytest.mark.asyncio
+async def test_undismiss_restores_item_to_get_recent():
+    item = make_item(url="https://example.com/undismiss", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+        await repo.dismiss(item.id)
+        assert await repo.is_dismissed(item.id) is True
+        await repo.undismiss(item.id)
+        assert await repo.is_dismissed(item.id) is False
+        items = await repo.get_recent(hours=24)
+    assert item.id in {i.id for i in items}
+
+
+@pytest.mark.asyncio
+async def test_dismiss_feature_flag_off_preserves_legacy_behaviour(monkeypatch):
+    """With dismiss_on_downvote=False the NOT IN subquery is skipped and a
+    dismissed item is still returned (the flag is an emergency escape hatch)."""
+    from news_agent.config import settings as _cfg
+
+    monkeypatch.setattr(_cfg, "dismiss_on_downvote", False)
+    item = make_item(url="https://example.com/flag-off", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+        await repo.dismiss(item.id)
+        items = await repo.get_recent(hours=24)
+    assert item.id in {i.id for i in items}

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -237,6 +237,71 @@ async def test_upvote_cancels_existing_downvote(client, isolated_db):
     assert "upvote" in actions
 
 
+# ── Tombstones via /api/interaction (T1-A / issue #1) ─────────────────────────
+
+@pytest.mark.asyncio
+async def test_interaction_downvote_inserts_tombstone(client, isolated_db):
+    from news_agent.storage.database import get_session
+    from news_agent.storage.repository import NewsRepository
+
+    item = make_item(url="https://example.com/downvote-tombstone", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+
+    resp = await client.post(
+        "/api/interaction",
+        json={"item_id": item.id, "action": "downvote"},
+    )
+    assert resp.status_code == 200
+
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        assert await repo.is_dismissed(item.id) is True
+
+
+@pytest.mark.asyncio
+async def test_interaction_upvote_clears_existing_tombstone(client, isolated_db):
+    """Upvoting a previously-downvoted item must un-tombstone it so the user
+    sees it again — matches the existing vote mutual-exclusion semantics."""
+    from news_agent.storage.database import get_session
+    from news_agent.storage.repository import NewsRepository
+
+    item = make_item(url="https://example.com/upvote-untombstone", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+
+    await client.post("/api/interaction", json={"item_id": item.id, "action": "downvote"})
+    async with get_session() as session:
+        assert await NewsRepository(session).is_dismissed(item.id) is True
+
+    await client.post("/api/interaction", json={"item_id": item.id, "action": "upvote"})
+    async with get_session() as session:
+        assert await NewsRepository(session).is_dismissed(item.id) is False
+
+
+@pytest.mark.asyncio
+async def test_interaction_undownvote_clears_tombstone(client, isolated_db):
+    """Explicit undownvote (user clicks the already-active downvote button to
+    toggle it off) must also clear the tombstone."""
+    from news_agent.storage.database import get_session
+    from news_agent.storage.repository import NewsRepository
+
+    item = make_item(url="https://example.com/undownvote-untombstone", published_at=hours_ago(1))
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+
+    await client.post("/api/interaction", json={"item_id": item.id, "action": "downvote"})
+    async with get_session() as session:
+        assert await NewsRepository(session).is_dismissed(item.id) is True
+
+    await client.post("/api/interaction", json={"item_id": item.id, "action": "undownvote"})
+    async with get_session() as session:
+        assert await NewsRepository(session).is_dismissed(item.id) is False
+
+
 @pytest.mark.asyncio
 async def test_downvote_does_not_cancel_if_already_unupvoted(client, isolated_db):
     """If upvote was already cancelled (unupvote), downvoting should not add another unupvote."""


### PR DESCRIPTION
Closes #1.

## Problem

`UserInteractionORM` records a `downvote`, but `NewsRepository.get_recent()` and `.search()` don't exclude downvoted items. The next 4-hour scheduler run re-upserts the same (source, url) pair under the same `sha256(source:url)[:16]` id and the article reappears in the panel. Users have to downvote the same item repeatedly.

## Solution

Miniflux-style tombstone table. When a user downvotes, we insert a row in `dismissed_items(item_id, dismissed_at, reason)`. `get_recent()` and `search()` filter it out via `NOT IN (SELECT item_id FROM dismissed_items)`. Upvoting or explicitly undownvoting clears the tombstone — matches the existing mutual-exclusion semantics in `_cancel_opposite_vote`.

Write-once analysis fields, hybrid-alpha defaults, and the existing fetch pipeline are untouched.

## Changes

- `news_agent/models.py` — new `DismissedItemORM` (PK `item_id`, `dismissed_at`, `reason`).
- `news_agent/storage/repository.py` — `dismiss()` / `undismiss()` / `is_dismissed()` helpers; `_dismissed_subquery()` injected into `get_recent()` and `search()` behind the feature flag.
- `news_agent/web/app.py` — `/api/interaction` hooks the lifecycle: `downvote` dismisses, `upvote` / `undownvote` clears.
- `news_agent/config.py` — new `dismiss_on_downvote: bool = True` flag. Default enabled (user-visible bugfix). Set `False` to restore legacy behaviour.

No migration script needed: `Base.metadata.create_all` in `init_db` creates the new table idempotently on next startup.

## Tests

9 new tests, all green. Full suite **354 passed, 0 regressions**.

Repository layer (`tests/storage/test_repository_extended.py`):
- `test_dismiss_inserts_tombstone_row`
- `test_dismiss_is_idempotent`
- `test_get_recent_excludes_dismissed_items`
- `test_dismissed_item_stays_hidden_after_reupsert` — **the core regression test**: dismiss → re-upsert the same (source, url) → still hidden
- `test_undismiss_restores_item_to_get_recent`
- `test_dismiss_feature_flag_off_preserves_legacy_behaviour`

Endpoint layer (`tests/web/test_app.py`):
- `test_interaction_downvote_inserts_tombstone`
- `test_interaction_upvote_clears_existing_tombstone`
- `test_interaction_undownvote_clears_tombstone`

## Rollout / rollback

- Forward: merge → next `init_db` creates the `dismissed_items` table → downvotes immediately start populating it.
- Rollback: set `DISMISS_ON_DOWNVOTE=false` in `.env` and restart. The empty table is harmless.

## Risk

- **R1 from the roadmap** (legitimate re-interest hidden forever): mitigated by upvote-clears-tombstone (tested) and the feature flag.
- **R8** (near-duplicate of dismissed item reappears via semantic dedup): unchanged by this PR — the tombstone is keyed by exact `item_id`, so a different URL with near-identical content will still surface. A follow-up could extend the check to `cluster_id`.

Made with [Cursor](https://cursor.com)