### PR TITLE
chore: gitignore EXPLAINER.md and sibling venv dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ pip-wheel-metadata/
 
 # ── Virtual environments ────────────────────────────────────────────────────
 .venv/
+.venv-*/
 venv/
 env/
 ENV/
@@ -70,6 +71,7 @@ data/
 # ── Local scratch files / notes ─────────────────────────────────────────────
 TODO.md
 NOTES.md
+EXPLAINER.md
 scratch/
 tmp/
 


### PR DESCRIPTION
Two tiny additions to `.gitignore`:

- **`EXPLAINER.md`** — a locally-generated codebase walkthrough the maintainer keeps for personal reference, same treatment as `TODO.md` / `NOTES.md` already in the same section.
- **`.venv-*/`** — matches sibling venv directories like `.venv-linux/`. Needed on Windows machines where the primary `.venv/` is a Windows venv that WSL can't execute, so a separate Linux venv lives at `.venv-linux/` alongside it.

No code changes.

Made with [Cursor](https://cursor.com)