### PR TITLE
feat(search): expose hybrid_alpha knob for BM25/semantic blend (T1-C, #3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,13 @@ DEDUP_STRATEGY=semantic
 DEDUP_SIMILARITY_THRESHOLD=0.82
 BATCH_SIZE=15
 MAX_ITEMS_PER_SOURCE=1000
+
+# ── Search ──────────────────────────────────────────────────────────────────
+# Hybrid BM25/semantic blend for search (0..1). 1.0 = pure BM25 (keyword,
+# tickers), 0.0 = pure semantic (paraphrase), 0.5 = legacy balanced RRF.
+# Override per-request with /api/panel?alpha=0.8 .
+DEFAULT_HYBRID_ALPHA=0.5
+TICKER_ALPHA=0.75
 # Faster/cheaper model for bulk scoring (relevance/tags/sentiment).
 ANALYSIS_MODEL=gemini/gemini-2.5-flash
 # API key for the analysis model (set when using a different provider than the main LLM)

--- a/news_agent/cli.py
+++ b/news_agent/cli.py
@@ -408,6 +408,111 @@ def newsletter_preview(
     asyncio.run(_run())
 
 
+# ── debug-alpha ───────────────────────────────────────────────────────────────
+
+@main.command("debug-alpha")
+@click.argument("query")
+@click.option("--hours", default=168, show_default=True, help="Look back N hours")
+@click.option("--limit", default=10, show_default=True, help="Results to print per alpha")
+@click.option(
+    "--alphas",
+    default="1.0,0.5,0.0",
+    show_default=True,
+    help="Comma-separated hybrid_alpha values to compare",
+)
+def debug_alpha(query: str, hours: int, limit: int, alphas: str):
+    """Compare hybrid BM25/semantic rankings at different alpha values.
+
+    Bypasses the web layer and any post-RRF re-rankers, so you see the raw
+    effect of the hybrid_alpha knob on NewsRepository.search() ordering.
+
+    \b
+      alpha=1.0 → BM25-only (exact keyword / ticker matches)
+      alpha=0.5 → balanced (legacy unweighted RRF)
+      alpha=0.0 → semantic-only (paraphrase / concepts)
+
+    Example:
+
+    \b
+      news-agent debug-alpha NVDA --hours 720
+      news-agent debug-alpha "interest rate cuts" --alphas 1.0,0.7,0.3,0.0
+    """
+    from news_agent.storage import init_db, get_session
+    from news_agent.storage.repository import NewsRepository
+
+    try:
+        alpha_values = [float(a.strip()) for a in alphas.split(",") if a.strip()]
+    except ValueError:
+        console.print(f"[red]--alphas must be comma-separated floats, got: {alphas!r}[/]")
+        sys.exit(2)
+    if not alpha_values:
+        console.print("[red]--alphas produced no values[/]")
+        sys.exit(2)
+
+    async def _run():
+        await init_db()
+        results: dict[float, list] = {}
+        async with get_session() as session:
+            repo = NewsRepository(session)
+            for a in alpha_values:
+                items = await repo.search(
+                    query, hours=hours, limit=limit, hybrid_alpha=a,
+                )
+                results[a] = items[:limit]
+
+        # Give every id seen across any column a stable colour so you can
+        # scan the table vertically and see which items move where.
+        palette = ["cyan", "magenta", "green", "yellow", "blue", "red", "white"]
+        colour_for: dict[str, str] = {}
+        for items in results.values():
+            for it in items:
+                if it.id not in colour_for:
+                    colour_for[it.id] = palette[len(colour_for) % len(palette)]
+
+        table = Table(title=f'Hybrid alpha sweep — query="{query}" hours={hours}')
+        table.add_column("Rank", justify="right", style="dim")
+        for a in alpha_values:
+            table.add_column(f"α={a}", overflow="fold")
+
+        for rank in range(limit):
+            row = [str(rank + 1)]
+            for a in alpha_values:
+                items = results[a]
+                if rank >= len(items):
+                    row.append("[dim]—[/]")
+                    continue
+                it = items[rank]
+                colour = colour_for[it.id]
+                title = it.title[:64] + ("…" if len(it.title) > 64 else "")
+                row.append(f"[{colour}]{title}[/]\n[dim]{it.source}[/]")
+            table.add_row(*row)
+        console.print(table)
+
+        # Jaccard overlap between top-N sets (membership change, ignoring order).
+        # Helps answer "did the knob actually change anything?"
+        def _jaccard(a_list, b_list) -> float:
+            a_ids = {i.id for i in a_list}
+            b_ids = {i.id for i in b_list}
+            if not a_ids and not b_ids:
+                return 1.0
+            return len(a_ids & b_ids) / len(a_ids | b_ids)
+
+        if len(alpha_values) >= 2:
+            console.print("\n[bold]Top-{n} set overlap (Jaccard):[/]".format(n=limit))
+            for i in range(len(alpha_values)):
+                for j in range(i + 1, len(alpha_values)):
+                    a1, a2 = alpha_values[i], alpha_values[j]
+                    j_ = _jaccard(results[a1], results[a2])
+                    marker = (
+                        "[green](different)[/]" if j_ < 0.8
+                        else "[yellow](mostly same)[/]" if j_ < 1.0
+                        else "[dim](identical)[/]"
+                    )
+                    console.print(f"  α={a1} vs α={a2}: {j_:.2f}  {marker}")
+
+    asyncio.run(_run())
+
+
 # ── sources ───────────────────────────────────────────────────────────────────
 
 @main.command()

--- a/news_agent/config.py
+++ b/news_agent/config.py
@@ -148,6 +148,16 @@ class Settings(BaseSettings):
     batch_size: int = 15
     max_items_per_source: int = 50
 
+    # ── Search ────────────────────────────────────────────────────────────────
+    # Blend factor for hybrid BM25 + semantic RRF fusion. 1.0 = pure BM25
+    # (keyword-dominant; good for tickers, proper nouns). 0.0 = pure semantic
+    # (good for paraphrases, concepts). 0.5 reproduces the legacy unweighted
+    # RRF behaviour. Per-request override via /api/panel?alpha=... .
+    default_hybrid_alpha: float = 0.5
+    # When T2-A (smart filter) detects a ticker-like query, this alpha is used
+    # instead of default_hybrid_alpha. Unused until T2-A lands.
+    ticker_alpha: float = 0.75
+
     # ── Personalization ───────────────────────────────────────────────────────
     # When True, a user downvote inserts a row in DismissedItemORM and the item
     # is hidden from get_recent() / search() across sessions and re-fetches.

--- a/news_agent/storage/repository.py
+++ b/news_agent/storage/repository.py
@@ -28,13 +28,31 @@ def _fts_escape(query: str) -> str:
     return " ".join(f'"{w}"' for w in words) if words else '""'
 
 
-def _rrf_merge(ranked_lists: list[list[str]], k: int = 60) -> list[str]:
+def _rrf_merge(
+    ranked_lists: list[list[str]],
+    k: int = 60,
+    weights: list[float] | None = None,
+) -> list[str]:
     """Reciprocal Rank Fusion: merge ranked ID lists, rewarding IDs that rank
-    highly in multiple lists. k=60 is the standard RRF constant."""
+    highly in multiple lists. k=60 is the standard RRF constant.
+
+    weights: optional per-list multiplier applied to each list's RRF score.
+    None → all lists weighted equally (legacy behaviour). Passing e.g.
+    [1.0, 0.0] reduces to the first list only. Any scaled pair (c, c) is
+    equivalent to None up to a constant factor and produces the same order.
+    Must have the same length as ranked_lists if provided.
+    """
+    if weights is not None and len(weights) != len(ranked_lists):
+        raise ValueError(
+            f"weights length {len(weights)} != ranked_lists length {len(ranked_lists)}"
+        )
     scores: dict[str, float] = {}
-    for ranked in ranked_lists:
+    for i, ranked in enumerate(ranked_lists):
+        w = 1.0 if weights is None else float(weights[i])
+        if w == 0.0:
+            continue  # skip entirely to avoid adding zero-weighted ids into dict
         for rank, id_ in enumerate(ranked):
-            scores[id_] = scores.get(id_, 0.0) + 1.0 / (k + rank + 1)
+            scores[id_] = scores.get(id_, 0.0) + w * (1.0 / (k + rank + 1))
     return sorted(scores.keys(), key=lambda x: scores[x], reverse=True)
 
 
@@ -202,6 +220,7 @@ class NewsRepository:
         limit: int = 60,
         languages: list[str] | None = None,
         min_relevance: float = 4.0,
+        hybrid_alpha: float | None = None,
     ) -> list[NewsItem]:
         """Content-based search using BM25 + semantic (RRF merge).
 
@@ -212,6 +231,13 @@ class NewsRepository:
 
         Items scored below min_relevance by the LLM are excluded; un-analyzed
         items (NULL relevance_score) are always included.
+
+        hybrid_alpha in [0, 1] controls the BM25 vs semantic blend:
+          1.0 → BM25-only (tickers, proper nouns)
+          0.5 → balanced (default; equivalent to legacy unweighted RRF)
+          0.0 → semantic-only (paraphrase, concepts)
+        None → use settings.default_hybrid_alpha. Values outside [0, 1] are
+        clamped silently.
         """
         since = datetime.utcnow() - timedelta(hours=hours)
         max_age = datetime.utcnow() - timedelta(days=7)
@@ -238,7 +264,12 @@ class NewsRepository:
             self.bm25_search(query, limit=limit * 2),
             semantic_search(query, top_k=limit * 3, expand=expand),
         )
-        candidate_ids = _rrf_merge([bm25_ids, vector_ids])
+        if hybrid_alpha is None:
+            hybrid_alpha = settings.default_hybrid_alpha
+        alpha = max(0.0, min(1.0, float(hybrid_alpha)))
+        candidate_ids = _rrf_merge(
+            [bm25_ids, vector_ids], weights=[alpha, 1.0 - alpha]
+        )
 
         rows = []
         if candidate_ids:

--- a/news_agent/web/app.py
+++ b/news_agent/web/app.py
@@ -617,8 +617,18 @@ async def digest_stream(topic: str, hours: float = 24):
 
 
 @app.get("/api/panel", response_class=HTMLResponse)
-async def panel_fragment(topic: str = "", hours: float = 24, langs: str = ""):
-    """Return just the news-list inner HTML for a single panel (used for live updates)."""
+async def panel_fragment(
+    topic: str = "",
+    hours: float = 24,
+    langs: str = "",
+    alpha: float | None = None,
+):
+    """Return just the news-list inner HTML for a single panel (used for live updates).
+
+    `alpha` (0..1) overrides the hybrid BM25/semantic blend for this request.
+    Out-of-range values are clamped in NewsRepository.search. None leaves the
+    configured default_hybrid_alpha in effect.
+    """
     import asyncio
     from news_agent.collectors.rss import _resolve_url
 
@@ -637,7 +647,9 @@ async def panel_fragment(topic: str = "", hours: float = 24, langs: str = ""):
     async with get_session() as session:
         repo = NewsRepository(session)
         if topic:
-            items = await repo.search(topic, hours=search_hours, languages=languages)
+            items = await repo.search(
+                topic, hours=search_hours, languages=languages, hybrid_alpha=alpha,
+            )
         else:
             items = await repo.get_recent(hours=hours, limit=60, languages=languages)
         prefs = await get_preference_scores(session)

--- a/tests/storage/test_search.py
+++ b/tests/storage/test_search.py
@@ -225,3 +225,116 @@ async def test_search_respects_hours_window():
     result_ids = [r.id for r in results]
     assert recent.id in result_ids, "Recent article should be in 24h window"
     assert old.id not in result_ids, "200h-old article should be outside 24h window"
+
+
+# ── hybrid_alpha knob (T1-C) ──────────────────────────────────────────────────
+
+class TestRrfMergeWeights:
+    def test_weights_none_matches_legacy(self):
+        """No weights argument must reproduce the pre-T1-C behaviour exactly."""
+        a = ["x", "y", "z"]
+        b = ["y", "z", "w"]
+        assert _rrf_merge([a, b]) == _rrf_merge([a, b], weights=None)
+
+    def test_equal_weights_match_none(self):
+        """Equal non-zero weights are a constant factor on all scores → same order."""
+        a = ["x", "y", "z"]
+        b = ["y", "w", "x"]
+        assert _rrf_merge([a, b], weights=[1.0, 1.0]) == _rrf_merge([a, b])
+        assert _rrf_merge([a, b], weights=[0.5, 0.5]) == _rrf_merge([a, b])
+
+    def test_alpha_one_is_bm25_only(self):
+        """weights=[1, 0] must yield BM25's order, ignoring the vector list."""
+        bm25 = ["bm1", "bm2", "bm3"]
+        vec  = ["vec1", "vec2", "vec3"]
+        merged = _rrf_merge([bm25, vec], weights=[1.0, 0.0])
+        assert merged == bm25
+
+    def test_alpha_zero_is_semantic_only(self):
+        """weights=[0, 1] must yield the semantic order, ignoring BM25."""
+        bm25 = ["bm1", "bm2", "bm3"]
+        vec  = ["vec1", "vec2", "vec3"]
+        merged = _rrf_merge([bm25, vec], weights=[0.0, 1.0])
+        assert merged == vec
+
+    def test_weights_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            _rrf_merge([["a"], ["b"]], weights=[1.0])
+        with pytest.raises(ValueError):
+            _rrf_merge([["a"], ["b"]], weights=[1.0, 0.5, 0.3])
+
+    def test_skewed_weights_promote_one_list(self):
+        """The top-ranked id of a heavily-weighted list must outrank the top-ranked
+        id of a lightly-weighted list when they are disjoint.
+
+        (We deliberately don't assert merged[0] here because a "shared" id at
+        rank 1 of both lists can still edge out the weighted leader; that is
+        the expected fused-ranking behaviour. The property this test pins down
+        is a strict comparison between the two list leaders.)
+        """
+        bm25 = ["heavy_top", "bm_filler_1", "bm_filler_2"]
+        vec  = ["vec_top", "vec_filler_1", "vec_filler_2"]
+        merged = _rrf_merge([bm25, vec], weights=[0.9, 0.1])
+        assert merged.index("heavy_top") < merged.index("vec_top")
+        merged_flipped = _rrf_merge([bm25, vec], weights=[0.1, 0.9])
+        assert merged_flipped.index("vec_top") < merged_flipped.index("heavy_top")
+
+
+@pytest.mark.asyncio
+async def test_search_alpha_out_of_range_is_clamped(monkeypatch):
+    """search(hybrid_alpha=...) must clamp to [0, 1] silently, not raise."""
+    from news_agent.storage.database import get_session, init_db
+    from news_agent.storage.repository import NewsRepository
+
+    await init_db()
+    item = make_item(
+        url="https://example.com/clamp-test",
+        title="NVDA surges on strong guidance",
+        content="NVDA posted a blowout quarter and raised guidance.",
+        published_at=hours_ago(2),
+    )
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        await repo.upsert(item)
+        # Out-of-range values must not raise and must still return sane results.
+        r_hi = await repo.search("NVDA", hours=24, limit=10, hybrid_alpha=5.0)
+        r_lo = await repo.search("NVDA", hours=24, limit=10, hybrid_alpha=-3.0)
+        r_one = await repo.search("NVDA", hours=24, limit=10, hybrid_alpha=1.0)
+        r_zero = await repo.search("NVDA", hours=24, limit=10, hybrid_alpha=0.0)
+
+    # Clamped: 5.0 → 1.0, -3.0 → 0.0, so the result sets should match the
+    # already-clamped boundary calls on the same index state.
+    assert [i.id for i in r_hi] == [i.id for i in r_one]
+    assert [i.id for i in r_lo] == [i.id for i in r_zero]
+
+
+@pytest.mark.asyncio
+async def test_search_alpha_none_uses_default(monkeypatch):
+    """hybrid_alpha=None must fall back to settings.default_hybrid_alpha and
+    produce the same ranking as passing that value explicitly."""
+    from news_agent.config import settings
+    from news_agent.storage.database import get_session, init_db
+    from news_agent.storage.repository import NewsRepository
+
+    monkeypatch.setattr(settings, "default_hybrid_alpha", 0.5)
+
+    await init_db()
+    items = [
+        make_item(
+            url=f"https://example.com/alpha-none-{i}",
+            title=f"Claude Sonnet update {i}",
+            content="Anthropic released another Claude Sonnet revision with tweaks.",
+            published_at=hours_ago(i + 1),
+        )
+        for i in range(3)
+    ]
+    async with get_session() as session:
+        repo = NewsRepository(session)
+        for it in items:
+            await repo.upsert(it)
+        r_default = await repo.search("Claude Sonnet", hours=24, limit=10)
+        r_explicit = await repo.search(
+            "Claude Sonnet", hours=24, limit=10, hybrid_alpha=0.5
+        )
+
+    assert [i.id for i in r_default] == [i.id for i in r_explicit]


### PR DESCRIPTION
## Summary
- Make the BM25 vs semantic RRF fusion weight tunable instead of hard-coded equal. `_rrf_merge` now takes an optional `weights` list; unweighted / equal-weighted calls reproduce the legacy ordering exactly.
- `NewsRepository.search` gains `hybrid_alpha: float | None`. `None` → `settings.default_hybrid_alpha` (0.5, matches legacy). Values are clamped to `[0, 1]` silently so a bad `?alpha=` can't 500 the request.
- `/api/panel` accepts an optional `?alpha=` query param (forwarded only on topic search — empty-topic "recent" listings are unaffected).
- New settings: `default_hybrid_alpha=0.5`, `ticker_alpha=0.75` (reserved for T2-A), documented in `.env.example`.

## Blast radius
- `digest_stream` and the home-page twin-panel search still use the default — no behaviour change on unchanged call sites.
- Legacy `_rrf_merge(lists)` callers get identical output (covered by `test_weights_none_matches_legacy`, `test_equal_weights_match_none`).

## Test plan
- [x] 6 `_rrf_merge` weight-invariant tests (equivalence with None, `[1,0]` = BM25-only, `[0,1]` = semantic-only, skewed weights promote the heavier list's leader, length-mismatch raises).
- [x] 2 integration tests on `search()`: clamp out-of-range alpha, `None` falls back to `default_hybrid_alpha`.
- [x] Full suite: **362 passed** (354 → 362; +8 new, no regressions).
- [ ] Manual smoke: `curl "localhost:8000/api/panel?topic=NVDA&alpha=1.0"` vs `alpha=0.0` should yield visibly different orderings (deferred until merged; not required for correctness).

Closes #3

Made with [Cursor](https://cursor.com)